### PR TITLE
Bump version to 0.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as f:
 
 setup(
     name='enthought_sphinx_theme',
-    version='0.5',
+    version='0.6',
     author='Enthought, Inc.',
     author_email='info@enthought.com',
     description='Sphinx theme for Enthought products',


### PR DESCRIPTION
Bumping version to ~~0.6.0~~ 0.6 prior to PyPI release. (I'm not sure when/where version 0.5 was released, but there have been a number of changes since then.)