### PR TITLE
Fix broken search functionality.

### DIFF
--- a/enthought_sphinx_theme/enthought/layout.html
+++ b/enthought_sphinx_theme/enthought/layout.html
@@ -126,7 +126,9 @@
     {%- endblock %}
     {{ css() }}
     {%- if not embedded %}
-    {{ script() }}
+    {%- block scripts %}
+    {{- script() }}
+    {%- endblock %}
     {%- if use_opensearch %}
     <link rel="search" type="application/opensearchdescription+xml"
           title="{% trans docstitle=docstitle|e %}Search within {{ docstitle }}{% endtrans %}"


### PR DESCRIPTION
With Sphinx 1.8.5, documentation generated using this theme has a broken search field: searches fail with a JavaScript error resembling the following:

```
jQuery.Deferred exception: Search is not defined ReferenceError: Search is not defined
    at HTMLDocument.<anonymous> (file:///Users/mdickinson/Enthought/ETS/traits/docs/build/html/search.html?q=HasRequiredTraits&check_keywords=yes&area=default:33:25)
    at j (file:///Users/mdickinson/Enthought/ETS/traits/docs/build/html/_static/jquery.js:2:29999)
    at k (file:///Users/mdickinson/Enthought/ETS/traits/docs/build/html/_static/jquery.js:2:30313) undefined
```

This PR fixes the issue for me: in current Sphinx, `search.html` has a `scripts` template block which calls `super()` and then appends `searchtools.js`. But `layout.html` is missing the corresponding `scripts` template block.


@rkern Do you have bandwidth for a review?