### PR TITLE
RELEASE 0.6.1: Add a release changelog and bump version number.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,9 +17,13 @@ Release date: 2019-05-10
 
 This is the first release made available on PyPI.
 
-* Fix favicon location. (#6)
+Changes
 
 * Update to current Enthought branding, fix for red font bleedthrough for code tags. (#5)
+
+Fixes
+
+* Fix favicon location. (#6)
 
 Release 0.5.0
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,29 @@
+Enthought Sphinx Theme changelog
+================================
+
+Release 0.6.1
+-------------
+
+Release date: 2019-06-20
+
+Fixes
+
+* Fix broken search box functionality. (#8)
+
+Release 0.6.0
+-------------
+
+Release date: 2019-05-10
+
+This is the first release made available on PyPI.
+
+* Fix favicon location. (#6)
+
+* Update to current Enthought branding, fix for red font bleedthrough for code tags. (#5)
+
+Release 0.5.0
+-------------
+
+Release date: 2014-10-17
+
+Initial release.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as f:
 
 setup(
     name='enthought_sphinx_theme',
-    version='0.6',
+    version='0.6.1',
     author='Enthought, Inc.',
     author_email='info@enthought.com',
     description='Sphinx theme for Enthought products',


### PR DESCRIPTION
Add a  brief changelog for 0.6.1 release, and retrospectively expand it to cover previous releases.