### PR TITLE
Add missing variable definition needed for search on Sphinx 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Enthought Sphinx Theme changelog
 ================================
 
+Release 0.6.2
+-------------
+
+Release date: 2020-04-29
+
+Fixes
+
+* More search functionality fixes. (#12)
+
 Release 0.6.1
 -------------
 

--- a/enthought_sphinx_theme/enthought/layout.html
+++ b/enthought_sphinx_theme/enthought/layout.html
@@ -98,6 +98,7 @@
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '{{ '' if no_search_suffix else file_suffix }}',
         LINK_SUFFIX: '{{ link_suffix }}',
+        SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}',
         HAS_SOURCE:  {{ has_source|lower }}
       };
     </script>

--- a/enthought_sphinx_theme/enthought/layout.html
+++ b/enthought_sphinx_theme/enthought/layout.html
@@ -214,7 +214,7 @@
             {% endif %}
   {%- block document %}
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             {% block body %} {% endblock %}
           </div>
         </div>

--- a/enthought_sphinx_theme/enthought/layout.html
+++ b/enthought_sphinx_theme/enthought/layout.html
@@ -97,6 +97,7 @@
         VERSION:     '{{ release|e }}',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '{{ '' if no_search_suffix else file_suffix }}',
+        LINK_SUFFIX: '{{ link_suffix }}',
         HAS_SOURCE:  {{ has_source|lower }}
       };
     </script>

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as f:
 
 setup(
     name='enthought_sphinx_theme',
-    version='0.6.1',
+    version='0.6.2',
     author='Enthought, Inc.',
     author_email='info@enthought.com',
     description='Sphinx theme for Enthought products',


### PR DESCRIPTION
Search is currently broken with Sphinx 3: the search results lead to an invalid URL containing an "undefined" string. 

xref: enthought/traits#1046.
xref: enthought/traits#1048

This PR fixes that.

Before this goes in, I'll check for other definitions that are present with the upstream theme but not here.