### PR TITLE
Prepare for 0.7.2 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Enthought Sphinx Theme changelog
 ================================
 
+Release 0.7.2
+-------------
+
+Release date: 2022-08-10
+
+Changes
+
+* Fix broken references to ``glyphicons-halflings.png``. (#18)
+
 Release 0.7.1
 -------------
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as f:
 
 setup(
     name='enthought_sphinx_theme',
-    version='0.7.1',
+    version='0.7.2',
     author='Enthought, Inc.',
     author_email='info@enthought.com',
     description='Sphinx theme for Enthought products',


### PR DESCRIPTION
This PR bumps the version and updates the changelog for a 0.7.2 bugfix release. The only change since 0.7.1 is the recently merged PR #18.

Note: no fancy release-branch shenanigans needed here - we'll make the release directly from the main branch once this PR is merged.