### PR TITLE
Remove use of deprecated "style" template variable

### DIFF
--- a/enthought_sphinx_theme/enthought/layout.html
+++ b/enthought_sphinx_theme/enthought/layout.html
@@ -112,7 +112,7 @@
 {%- macro css() %}
     <link rel="stylesheet" type="text/css" href="{{ pathto('_static/css/spc-bootstrap.css', 1) }}">
     <link rel="stylesheet" type="text/css" href="{{ pathto('_static/css/spc-extend.css', 1) }}">
-    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" >
+    <link rel="stylesheet" href="{{ pathto('_static/' + styles[0], 1) }}" type="text/css" >
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" >
     {%- for cssfile in css_files %}
     <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" >


### PR DESCRIPTION
Replace `style` by `styles[0]` (which is what it was holding prior to Sphinx 7.0)

Fixes #22 