### PR TITLE
Fix Sphinx 9 compatibility for CSS and JS asset rendering

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,6 @@ Release 0.7.4
 Changes
 
 * Fix Sphinx 9 compatibility for CSS and JS asset rendering. (#25)
-* Require Sphinx >= 4.5 (for ``css_tag``/``js_tag`` template helpers).
 
 Release 0.7.3
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Enthought Sphinx Theme changelog
 ================================
 
+Release 0.7.4
+-------------
+
+Changes
+
+* Fix Sphinx 9 compatibility for CSS and JS asset rendering. (#25)
+* Require Sphinx >= 4.5 (for ``css_tag``/``js_tag`` template helpers).
+
 Release 0.7.3
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Enthought Sphinx Theme changelog
 Release 0.7.4
 -------------
 
+Release date: 2026-02-16
+
 Changes
 
 * Fix Sphinx 9 compatibility for CSS and JS asset rendering. (#25)

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,6 @@ enthought-sphinx-theme
 Installation
 ------------
 
-Requires Sphinx >= 4.5.
-
 Install this as a normal Python package. The theme files are in the package
 data.
 
@@ -60,5 +58,5 @@ configuration variable:
 The following blocks are defined:
 
 - ``layout.html:header``
-   
+
   Block at the top of the page, for logo etc.

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,8 @@ enthought-sphinx-theme
 Installation
 ------------
 
+Requires Sphinx >= 4.5.
+
 Install this as a normal Python package. The theme files are in the package
 data.
 

--- a/README.rst
+++ b/README.rst
@@ -58,5 +58,5 @@ configuration variable:
 The following blocks are defined:
 
 - ``layout.html:header``
-
+   
   Block at the top of the page, for logo etc.

--- a/enthought_sphinx_theme/enthought/layout.html
+++ b/enthought_sphinx_theme/enthought/layout.html
@@ -103,7 +103,11 @@
       };
     </script>
     {%- for js in script_files %}
+      {%- if js|attr("filename") %}
     {{ js_tag(js) }}
+      {%- else %}
+    <script type="text/javascript" src="{{ pathto(js, 1) }}"></script>
+      {%- endif %}
     {%- endfor %}
     <script type="text/javascript" src="{{ pathto('_static/js/copybutton.js', 1) }}"></script>
     <script type="text/javascript" src="{{ pathto('_static/js/wrap_on_dot.js', 1) }}"></script>

--- a/enthought_sphinx_theme/enthought/layout.html
+++ b/enthought_sphinx_theme/enthought/layout.html
@@ -102,8 +102,12 @@
         HAS_SOURCE:  {{ has_source|lower }}
       };
     </script>
-    {%- for scriptfile in script_files %}
-    <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
+    {%- for js in script_files %}
+      {%- if js|attr("filename") is not none %}
+    {{ js_tag(js) }}
+      {%- else %}
+    <script type="text/javascript" src="{{ pathto(js, 1) }}"></script>
+      {%- endif %}
     {%- endfor %}
     <script type="text/javascript" src="{{ pathto('_static/js/copybutton.js', 1) }}"></script>
     <script type="text/javascript" src="{{ pathto('_static/js/wrap_on_dot.js', 1) }}"></script>
@@ -114,8 +118,12 @@
     <link rel="stylesheet" type="text/css" href="{{ pathto('_static/css/spc-extend.css', 1) }}">
     <link rel="stylesheet" href="{{ pathto('_static/' + styles[0], 1) }}" type="text/css" >
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" >
-    {%- for cssfile in css_files %}
-    <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" >
+    {%- for css in css_files %}
+      {%- if css|attr("filename") %}
+    {{ css_tag(css) }}
+      {%- else %}
+    <link rel="stylesheet" href="{{ pathto(css, 1) }}" type="text/css" >
+      {%- endif %}
     {%- endfor %}
 {%- endmacro %}
 

--- a/enthought_sphinx_theme/enthought/layout.html
+++ b/enthought_sphinx_theme/enthought/layout.html
@@ -103,11 +103,7 @@
       };
     </script>
     {%- for js in script_files %}
-      {%- if js|attr("filename") is not none %}
     {{ js_tag(js) }}
-      {%- else %}
-    <script type="text/javascript" src="{{ pathto(js, 1) }}"></script>
-      {%- endif %}
     {%- endfor %}
     <script type="text/javascript" src="{{ pathto('_static/js/copybutton.js', 1) }}"></script>
     <script type="text/javascript" src="{{ pathto('_static/js/wrap_on_dot.js', 1) }}"></script>

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ setup(
     url='https://github.com/enthought/enthought-sphinx-theme',
     packages=find_packages(),
     include_package_data=True,
+    install_requires=[
+        'Sphinx>=4.5',
+    ],
     license = "BSD",
     classifiers = [
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,6 @@ setup(
     url='https://github.com/enthought/enthought-sphinx-theme',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=[
-        'Sphinx>=4.5',
-    ],
     license = "BSD",
     classifiers = [
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as f:
 
 setup(
     name='enthought_sphinx_theme',
-    version='0.7.3',
+    version='0.7.4',
     author='Enthought, Inc.',
     author_email='info@enthought.com',
     description='Sphinx theme for Enthought products',


### PR DESCRIPTION
## Summary

- In Sphinx 9, `css_files` and `script_files` contain `_CascadingStyleSheet` and `_JavaScript` objects instead of plain strings. Passing these to `pathto()` causes `TypeError: argument of type '_CascadingStyleSheet' is not iterable`.
- Use `css_tag()` / `js_tag()` (available since Sphinx 7) to render asset objects, falling back to raw `<link>`/`<script>` tags for plain strings (older Sphinx). This mirrors Sphinx's own `basic/layout.html` approach.
- Fixes the doc build for downstream projects (e.g., traits) that resolve to Sphinx 9 via `Sphinx>=2.1.0`.

## Test plan

- [x] Verified traits doc build succeeds with Sphinx 9.1.0 on Python 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)