### PR TITLE
Pin GitHub Actions to full SHAs, and add a dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
     - name: Check out the release commit
-      uses: actions/checkout@v3
+      uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
       with:
         python-version: '3.11'
     - name: Install Python packages needed for build and upload


### PR DESCRIPTION
Pin the two actions used by the publish workflow to the commit that each floating major tag currently resolves to, so that a retagged or compromised action cannot change what runs during a release:

- `actions/checkout@v3` → `a37ce9120846195fa4ece8f58b268e6043cb2f26` (v3.7.0)
- `actions/setup-python@v4` → `7f4fc3e22c37d6ff65e88745f38bd3157c663f7c` (v4.9.1)

These are pins only, not upgrades — each SHA is what the major tag points at today. The corresponding version is kept in a trailing comment, which is also what dependabot reads when it proposes an update.

Add `.github/dependabot.yml` to keep those pins current, with a weekly schedule and a seven-day cooldown so that a release is not picked up the day it lands. Only the `github-actions` ecosystem is configured: `setup.py` declares no dependencies, and there is no lock file. This follows the configuration in the Envisage repository, minus its `uv` entry.

Once this merges, dependabot's first run should propose bumps to `actions/checkout` v7.0.1 and `actions/setup-python` v7.0.0, which verifies the configuration end to end. Both releases are well past seven days old, so the cooldown will not hold them back.

No changelog entry: every section of `CHANGES.rst` carries a release date, 0.7.5 has already shipped, and this change is not user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)