### PR TITLE
Publish to PyPI with trusted publishing

### DIFF
--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   build-and-upload:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
     - name: Check out the release commit
@@ -22,10 +26,8 @@ jobs:
     - name: Build sdist and wheel
       run: |
         python -m build
-    - name: Publish to PyPI
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    - name: Check the distribution
       run: |
         python -m twine check --strict dist/*
-        python -m twine upload dist/*
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -20,14 +20,11 @@ jobs:
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.14'
-    - name: Install Python packages needed for build and upload
+    - name: Install Python packages needed for the build
       run: |
-        python -m pip install build twine
+        python -m pip install build
     - name: Build sdist and wheel
       run: |
         python -m build
-    - name: Check the distribution
-      run: |
-        python -m twine check --strict dist/*
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
-        python-version: '3.11'
+        python-version: '3.14'
     - name: Install Python packages needed for build and upload
       run: |
         python -m pip install build twine


### PR DESCRIPTION
Replace the `twine upload`, which authenticated with a long-lived username and password held in repository secrets, by `pypa/gh-action-pypi-publish`. The action exchanges a short-lived OIDC token for an upload token, so no credential needs to be stored, and it generates PEP 740 attestations for the uploaded files.

This follows the workflow Envisage used at its 8.0.0 release, before that repository moved its build to uv, with the differences noted below.

Alongside the workflow change:

- `id-token: write` is granted to the job, which the OIDC exchange needs, and `contents: read` is stated explicitly.
- The job runs in a `pypi` environment, so the trusted publisher can be scoped to it on the PyPI side.
- The separate `twine check --strict` step is dropped, and twine with it. The action already runs `twine check` before uploading unless `verify-metadata` is set to `false`, and generates attestations only after that check passes, so metadata is still verified before anything is uploaded. The only thing `--strict` added was making two warnings fatal — a missing `long_description` and a missing `long_description_content_type` — and `setup.py` sets both, while a `long_description` that fails to render fails the check either way. Envisage kept this step at 8.0.0 but has since dropped it too, so this matches its current main.
- The build moves from Python 3.11 to 3.14. The published files are pure Python and do not depend on the interpreter that builds them; this just stops the release path from becoming the last place an old version lingers. Checked locally against 3.14.5: `python -m build` and `twine check --strict` both succeed and produce the same two filenames as before.

The publish action is pinned at the current v1.14.2 rather than Envisage's v1.14.1.

The `pypi` environment has been configured to match Envisage's, with a `*.*.*` tag deployment policy and no admin bypass, but without Envisage's required-reviewer rule, which is heavier than this repository warrants. Tags here are bare versions, so that pattern covers real releases; a consequence is that `workflow_dispatch` from a branch can no longer publish.

The trusted publisher for `enthought`/`enthought-sphinx-theme`, workflow `publish-on-pypi.yml`, environment `pypi`, is live on PyPI, so this is safe to merge.

The `PYPI_USERNAME` and `PYPI_PASSWORD` secrets become unused once this merges, but are worth keeping until a release has published this way. Deleting them is what actually retires the credential; revoking the token on PyPI is a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)